### PR TITLE
Add _tobytes function to convert tensor to bytes

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -7,7 +7,8 @@ from typing import cast, List, Literal, Optional, Union
 
 from diffusers.image_processor import VaeImageProcessor
 from diffusers.video_processor import VideoProcessor
-from safetensors.torch import _tobytes
+def _tobytes(tensor, name):
+    return tensor.contiguous().cpu().numpy().tobytes()
 
 DTYPE_MAP = {
     "float16": torch.float16,


### PR DESCRIPTION
_tobytes is a private function that was removed from newer versions of safetensors.  This fixes it.